### PR TITLE
sorting the way the relationships are updated to prevent neo4j deadlocks

### DIFF
--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jSession.java
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jSession.java
@@ -342,7 +342,13 @@ public class Neo4jSession extends AbstractSession<Session> {
         }
         if(entity.hasDynamicAssociations()) {
             if(!pendingRelationshipInserts.isEmpty()) {
-                Set<RelationshipUpdateKey> relationshipUpdates = pendingRelationshipInserts.keySet();
+                List<RelationshipUpdateKey> relationshipUpdates = new ArrayList<RelationshipUpdateKey>(pendingRelationshipInserts.keySet());
+                Collections.sort(relationshipUpdates, new Comparator<RelationshipUpdateKey>() {
+                    @Override
+                    public int compare(RelationshipUpdateKey o1, RelationshipUpdateKey o2) {
+                        return o1.association.getName().compareTo(o2.association.getName());
+                    }
+                });
                 for (RelationshipUpdateKey relationshipUpdate : relationshipUpdates) {
                     Association association = relationshipUpdate.association;
                     if(association instanceof DynamicToOneAssociation) {


### PR DESCRIPTION
In some cases, the order the relationship are updated are not the same, and that is leading to some neo4j deadlocks.