### PR TITLE
checking if dynamic property is dirty before adding it for save

### DIFF
--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jSession.java
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jSession.java
@@ -586,7 +586,9 @@ public class Neo4jSession extends AbstractSession<Session> {
 
                     }
                     else {
-                        simpleProps.put(key, ((Neo4jMappingContext)mappingContext).convertToNative(value));
+                        if (((DirtyCheckable)pojo).hasChanged(key)) {
+                            simpleProps.put(key, ((Neo4jMappingContext)mappingContext).convertToNative(value));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This makes db commits faster as it's only sending the dirty properties.