### PR TITLE
Changing Relationship DELETE query to use equals because it throws an…

### DIFF
--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/engine/RelationshipPendingInsert.java
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/engine/RelationshipPendingInsert.java
@@ -155,13 +155,13 @@ public class RelationshipPendingInsert extends PendingInsertAdapter<Object, Seri
             Map<String, Object> deleteParams;
             if(association instanceof DynamicToOneAssociation) {
                 cypher.append(graphChild.formatId(FROM));
-                deleteParams = Collections.singletonMap(CypherBuilder.START, parentId);
+                deleteParams = Collections.singletonMap(CypherBuilder.START, Collections.singletonList(parentId));
             }
             else {
                 cypher.append(graphChild.formatId(TO));
                 deleteParams = Collections.<String, Object>singletonMap(CypherBuilder.START, targetIdentifiers);
             }
-            cypher.append(" = {start} DELETE r");
+            cypher.append(" IN {start} DELETE r");
             if(log.isDebugEnabled()) {
                 log.debug("DELETE Cypher [{}] for parameters [{}]", cypher, deleteParams);
             }

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/engine/RelationshipPendingInsert.java
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/engine/RelationshipPendingInsert.java
@@ -161,7 +161,7 @@ public class RelationshipPendingInsert extends PendingInsertAdapter<Object, Seri
                 cypher.append(graphChild.formatId(TO));
                 deleteParams = Collections.<String, Object>singletonMap(CypherBuilder.START, targetIdentifiers);
             }
-            cypher.append(" IN {start} DELETE r");
+            cypher.append(" = {start} DELETE r");
             if(log.isDebugEnabled()) {
                 log.debug("DELETE Cypher [{}] for parameters [{}]", cypher, deleteParams);
             }

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/engine/RelationshipPendingInsert.java
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/engine/RelationshipPendingInsert.java
@@ -155,7 +155,7 @@ public class RelationshipPendingInsert extends PendingInsertAdapter<Object, Seri
             Map<String, Object> deleteParams;
             if(association instanceof DynamicToOneAssociation) {
                 cypher.append(graphChild.formatId(FROM));
-                deleteParams = Collections.singletonMap(CypherBuilder.START, Collections.singletonList(parentId));
+                deleteParams = Collections.<String, Object>singletonMap(CypherBuilder.START, Collections.singletonList(parentId));
             }
             else {
                 cypher.append(graphChild.formatId(TO));


### PR DESCRIPTION
… error when using IN and a single value