### PR TITLE
Issues when updating dynamic associations of a newly created objects.

### DIFF
--- a/grails-datastore-gorm-neo4j/src/main/groovy/grails/neo4j/Neo4jEntity.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/grails/neo4j/Neo4jEntity.groovy
@@ -26,7 +26,6 @@ import org.grails.datastore.gorm.neo4j.GraphPersistentEntity
 import org.grails.datastore.gorm.neo4j.Neo4jDatastore
 import org.grails.datastore.gorm.neo4j.Neo4jSession
 import org.grails.datastore.gorm.neo4j.collection.Neo4jResultList
-import org.grails.datastore.gorm.neo4j.engine.DynamicAssociationSupport
 import org.grails.datastore.gorm.neo4j.engine.Neo4jEntityPersister
 import org.grails.datastore.gorm.neo4j.extensions.Neo4jExtensions
 import org.grails.datastore.gorm.schemaless.DynamicAttributes
@@ -36,6 +35,10 @@ import org.grails.datastore.mapping.multitenancy.MultiTenancySettings
 import org.grails.datastore.mapping.multitenancy.exceptions.TenantNotFoundException
 import org.neo4j.driver.v1.StatementResult
 import org.neo4j.driver.v1.StatementRunner
+
+import static org.grails.datastore.gorm.neo4j.engine.DynamicAssociationSupport.areDynamicAssociationsLoaded
+import static org.grails.datastore.gorm.neo4j.engine.DynamicAssociationSupport.loadDynamicAssociations
+
 /**
  * Extends the default {@org.grails.datastore.gorm.GormEntity} trait, adding new methods specific to Neo4j
  *
@@ -64,10 +67,19 @@ trait Neo4jEntity<D> implements GormEntity<D>, DynamicAttributes {
      * @param val The value
      */
     def propertyMissing(String name, val) {
-        loadDynamicAssociations()
+        GormStaticApi staticApi = GormEnhancer.findStaticApi(getClass())
+        if (staticApi.gormPersistentEntity instanceof GraphPersistentEntity) {
+            GraphPersistentEntity entity = (GraphPersistentEntity) staticApi.gormPersistentEntity
+            if (entity.hasDynamicAssociations()) {
+                staticApi.withSession { Neo4jSession session ->
+                    if ( !areDynamicAssociationsLoaded(session, this) ) {
+                        loadDynamicAssociations(session, entity, this, ident())
+                    }
+                }
+            }
+        }
         DynamicAttributes.super.putAt(name, val)
     }
-
 
     /**
      * Obtains a dynamic attribute
@@ -83,25 +95,20 @@ trait Neo4jEntity<D> implements GormEntity<D>, DynamicAttributes {
     def getAtt(String name) {
         def val = DynamicAttributes.super.getAt(name)
         if (val == null) {
-            loadDynamicAssociations()
-            return DynamicAttributes.super.getAt(name)
-        }
-        return val
-    }
-
-    def private loadDynamicAssociations() {
-        GormStaticApi staticApi = GormEnhancer.findStaticApi(getClass())
-        if (staticApi.gormPersistentEntity instanceof GraphPersistentEntity) {
+            GormStaticApi staticApi = GormEnhancer.findStaticApi(getClass())
             if (staticApi.gormPersistentEntity instanceof GraphPersistentEntity) {
                 GraphPersistentEntity entity = (GraphPersistentEntity) staticApi.gormPersistentEntity
                 if (entity.hasDynamicAssociations()) {
-                    def id = ident()
                     staticApi.withSession { Neo4jSession session ->
-                        DynamicAssociationSupport.loadDynamicAssociations(session, entity, this, id)
+                        if ( !areDynamicAssociationsLoaded(session, this) ) {
+                            loadDynamicAssociations(session, entity, this, ident())
+                        }
                     }
                 }
             }
+            return DynamicAttributes.super.getAt(name)
         }
+        return val
     }
 
     /**

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/engine/DynamicAssociationSupport.java
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/engine/DynamicAssociationSupport.java
@@ -37,6 +37,10 @@ public class DynamicAssociationSupport {
 
     private static final Logger log = LoggerFactory.getLogger(DynamicAssociationSupport.class);
 
+    public static boolean areDynamicAssociationsLoaded(Neo4jSession session, DynamicAttributes object) {
+        return session.getAttribute(object, Neo4jEntityPersister.DYNAMIC_ASSOCIATION_PARAM) != null;
+    }
+
     public static Map<TypeDirectionPair, Map<String, Object>> loadDynamicAssociations(Neo4jSession session, GraphPersistentEntity graphPersistentEntity, DynamicAttributes object,  Serializable id) {
         Map<TypeDirectionPair, Map<String, Object>> relationshipsMap = new HashMap<>();
 
@@ -46,6 +50,7 @@ public class DynamicAssociationSupport {
             session.setAttribute(object, Neo4jEntityPersister.DYNAMIC_ASSOCIATION_PARAM, Boolean.TRUE);
 
             if (id == null) {
+                // at this point we have the object flagged as having dynamic associations loaded but as we don't have anything to load we just exit
                 return relationshipsMap;
             }
             final String cypher = graphPersistentEntity.formatDynamicAssociationQuery();

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/engine/DynamicAssociationSupport.java
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/engine/DynamicAssociationSupport.java
@@ -37,100 +37,90 @@ public class DynamicAssociationSupport {
 
     private static final Logger log = LoggerFactory.getLogger(DynamicAssociationSupport.class);
 
-    public static Map<TypeDirectionPair, Map<String, Object>> loadDynamicAssociations(Neo4jSession session,
-                                                                                      GraphPersistentEntity graphPersistentEntity,
-                                                                                      DynamicAttributes object,
-                                                                                      Serializable id) {
+    public static Map<TypeDirectionPair, Map<String, Object>> loadDynamicAssociations(Neo4jSession session, GraphPersistentEntity graphPersistentEntity, DynamicAttributes object,  Serializable id) {
         Map<TypeDirectionPair, Map<String, Object>> relationshipsMap = new HashMap<>();
 
         final boolean hasDynamicAssociations = graphPersistentEntity.hasDynamicAssociations();
-        if (id != null) {
-            Object alreadyLoaded = session.getAttribute(object, Neo4jEntityPersister.DYNAMIC_ASSOCIATION_PARAM);
-            if (alreadyLoaded == null && hasDynamicAssociations) {
-                session.setAttribute(object, Neo4jEntityPersister.DYNAMIC_ASSOCIATION_PARAM, Boolean.TRUE);
+        Object alreadyLoaded = session.getAttribute(object, Neo4jEntityPersister.DYNAMIC_ASSOCIATION_PARAM);
+        if(alreadyLoaded == null && hasDynamicAssociations) {
+            session.setAttribute(object, Neo4jEntityPersister.DYNAMIC_ASSOCIATION_PARAM, Boolean.TRUE);
 
-                final String cypher = graphPersistentEntity.formatDynamicAssociationQuery();
-                final Map<String, Object> isMap = Collections.<String, Object>singletonMap(GormProperties.IDENTITY, id);
-                final StatementRunner boltSession = session.hasTransaction() ? session.getTransaction().getNativeTransaction() : session.getNativeInterface();
+            if (id == null) {
+                return relationshipsMap;
+            }
+            final String cypher = graphPersistentEntity.formatDynamicAssociationQuery();
+            final Map<String, Object> isMap = Collections.<String, Object>singletonMap(GormProperties.IDENTITY, id);
+            final StatementRunner boltSession = session.hasTransaction() ? session.getTransaction().getNativeTransaction() : session.getNativeInterface();
 
-                if (log.isDebugEnabled()) {
-                    log.debug("QUERY Cypher [{}] for parameters [{}]", cypher, isMap);
-                }
+            if(log.isDebugEnabled()) {
+                log.debug("QUERY Cypher [{}] for parameters [{}]", cypher, isMap);
+            }
 
-                final StatementResult relationships = boltSession.run(cypher, isMap);
-                while (relationships.hasNext()) {
-                    final Record row = relationships.next();
-                    String relType = row.get("relType").asString();
-                    Boolean outGoing = row.get("out").asBoolean();
-                    Map<String, Object> values = row.get("values").asMap();
-                    TypeDirectionPair key = new TypeDirectionPair(relType, outGoing);
-                    if (row.containsKey(RelationshipPendingInsert.TARGET_TYPE) && !row.get(RelationshipPendingInsert.TARGET_TYPE).isNull()) {
-                        key.setTargetType(
+            final StatementResult relationships = boltSession.run(cypher, isMap);
+            while(relationships.hasNext()) {
+                final Record row = relationships.next();
+                String relType = row.get("relType").asString();
+                Boolean outGoing = row.get("out").asBoolean();
+                Map<String, Object> values = row.get("values").asMap();
+                TypeDirectionPair key = new TypeDirectionPair(relType, outGoing);
+                if(row.containsKey(RelationshipPendingInsert.TARGET_TYPE) && !row.get(RelationshipPendingInsert.TARGET_TYPE).isNull()) {
+                    key.setTargetType(
                             row.get(RelationshipPendingInsert.TARGET_TYPE).asString()
-                        );
-                        relationshipsMap.put(key, values);
-                    }
+                    );
+                    relationshipsMap.put(key, values);
                 }
-                // if the relationship map is not empty as this point there are dynamic relationships that need to be loaded as undeclared
-                if (!relationshipsMap.isEmpty()) {
-                    Neo4jMappingContext mappingContext = (Neo4jMappingContext) session.getMappingContext();
-                    for (Map.Entry<TypeDirectionPair, Map<String, Object>> entry : relationshipsMap.entrySet()) {
-                        EntityAccess entityAccess = session.createEntityAccess(graphPersistentEntity, object);
-                        TypeDirectionPair key = entry.getKey();
-                        if (key.isOutgoing()) {
-                            Map<String, Object> relationshipData = entry.getValue();
-                            Object idsObject = relationshipData.get("ids");
-                            Object labelsObject = relationshipData.get("labels");
-                            if ((idsObject instanceof Iterable) && (labelsObject instanceof Iterable)) {
+            }
+            // if the relationship map is not empty as this point there are dynamic relationships that need to be loaded as undeclared
+            if (!relationshipsMap.isEmpty()) {
+                Neo4jMappingContext mappingContext = (Neo4jMappingContext) session.getMappingContext();
+                for (Map.Entry<TypeDirectionPair, Map<String,Object>> entry: relationshipsMap.entrySet()) {
+                    EntityAccess entityAccess = session.createEntityAccess(graphPersistentEntity, object);
+                    TypeDirectionPair key = entry.getKey();
+                    if (key.isOutgoing()) {
+                        Map<String, Object> relationshipData = entry.getValue();
+                        Object idsObject = relationshipData.get("ids");
+                        Object labelsObject = relationshipData.get("labels");
+                        if((idsObject instanceof Iterable) && (labelsObject instanceof Iterable)) {
 
-                                Iterator<Serializable> idIter = ((Iterable<Serializable>) idsObject).iterator();
-                                String targetType = key.getTargetType();
-                                Iterator<Collection<String>> labelIter = ((Iterable<Collection<String>>) labelsObject).iterator();
+                            Iterator<Serializable> idIter = ((Iterable<Serializable>) idsObject).iterator();
+                            String targetType = key.getTargetType();
+                            Iterator<Collection<String>> labelIter = ((Iterable<Collection<String>>) labelsObject).iterator();
 
-                                List values = new ArrayList();
-                                GraphPersistentEntity associatedEntity = null;
-                                while (idIter.hasNext() && labelIter.hasNext()) {
-                                    Serializable targetId = idIter.next();
-                                    Collection<String> nextLabels = labelIter.next();
-                                    Collection<String> labels = nextLabels.isEmpty() ? Collections.singletonList(targetType) : nextLabels;
-                                    associatedEntity = mappingContext.findPersistentEntityForLabels(labels);
-                                    if (associatedEntity == null) {
-                                        associatedEntity = mappingContext.findPersistentEntityForLabels(Collections.singletonList(targetType));
-                                    }
-                                    if (associatedEntity == null) {
-                                        continue;
-                                    }
-                                    Object proxy = mappingContext.getProxyFactory().createProxy(
+                            List values = new ArrayList();
+                            GraphPersistentEntity associatedEntity = null;
+                            while (idIter.hasNext() && labelIter.hasNext()) {
+                                Serializable targetId = idIter.next();
+                                Collection<String> nextLabels = labelIter.next();
+                                Collection<String> labels = nextLabels.isEmpty() ? Collections.singletonList(targetType) : nextLabels;
+                                associatedEntity = mappingContext.findPersistentEntityForLabels(labels);
+                                if(associatedEntity == null) {
+                                    associatedEntity = mappingContext.findPersistentEntityForLabels(Collections.singletonList(targetType));
+                                }
+                                if(associatedEntity == null) {
+                                    continue;
+                                }
+                                Object proxy = mappingContext.getProxyFactory().createProxy(
                                         session,
                                         associatedEntity.getJavaClass(),
                                         targetId
-                                    );
-                                    values.add(proxy);
-                                }
-                                // for single instances and singular property name do not use an array
-                                Object value;
-                                if (values.size() == 1 && isSingular(key.getType())) {
-                                    value = IteratorUtil.singleOrNull(values);
-                                }
-                                else {
-                                    DynamicToManyAssociation dynamicAssociation = new DynamicToManyAssociation(graphPersistentEntity,
-                                                                                                               graphPersistentEntity.getMappingContext(),
-                                                                                                               key.getType(),
-                                                                                                               associatedEntity);
-                                    value = new Neo4jList(entityAccess, dynamicAssociation, values, session);
-                                }
-                                object.attributes().put(key.getType(), value);
+                                );
+                                values.add(proxy);
                             }
-
+                            // for single instances and singular property name do not use an array
+                            Object value;
+                            if(values.size() == 1 && isSingular(key.getType())) {
+                                value = IteratorUtil.singleOrNull(values);
+                            }
+                            else {
+                                DynamicToManyAssociation dynamicAssociation = new DynamicToManyAssociation(graphPersistentEntity, graphPersistentEntity.getMappingContext(), key.getType(), associatedEntity);
+                                value = new Neo4jList(entityAccess, dynamicAssociation, values, session);
+                            }
+                            object.attributes().put(key.getType(), value);
                         }
+
                     }
                 }
-
             }
-
-        }
-        else {
-            session.setAttribute(object, Neo4jEntityPersister.DYNAMIC_ASSOCIATION_PARAM, Boolean.TRUE);
         }
 
         return relationshipsMap;

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/engine/DynamicAssociationSupport.java
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/engine/DynamicAssociationSupport.java
@@ -1,5 +1,18 @@
 package org.grails.datastore.gorm.neo4j.engine;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.StatementRunner;
+
 import org.grails.datastore.gorm.neo4j.GraphPersistentEntity;
 import org.grails.datastore.gorm.neo4j.Neo4jMappingContext;
 import org.grails.datastore.gorm.neo4j.Neo4jSession;
@@ -11,14 +24,8 @@ import org.grails.datastore.gorm.neo4j.util.IteratorUtil;
 import org.grails.datastore.gorm.schemaless.DynamicAttributes;
 import org.grails.datastore.mapping.engine.EntityAccess;
 import org.grails.datastore.mapping.model.config.GormProperties;
-import org.neo4j.driver.v1.Record;
-import org.neo4j.driver.v1.StatementResult;
-import org.neo4j.driver.v1.StatementRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.Serializable;
-import java.util.*;
 
 /**
  * Support class for dynamic associations
@@ -30,87 +37,100 @@ public class DynamicAssociationSupport {
 
     private static final Logger log = LoggerFactory.getLogger(DynamicAssociationSupport.class);
 
-    public static Map<TypeDirectionPair, Map<String, Object>> loadDynamicAssociations(Neo4jSession session, GraphPersistentEntity graphPersistentEntity, DynamicAttributes object,  Serializable id) {
+    public static Map<TypeDirectionPair, Map<String, Object>> loadDynamicAssociations(Neo4jSession session,
+                                                                                      GraphPersistentEntity graphPersistentEntity,
+                                                                                      DynamicAttributes object,
+                                                                                      Serializable id) {
         Map<TypeDirectionPair, Map<String, Object>> relationshipsMap = new HashMap<>();
 
         final boolean hasDynamicAssociations = graphPersistentEntity.hasDynamicAssociations();
-        Object alreadyLoaded = session.getAttribute(object, Neo4jEntityPersister.DYNAMIC_ASSOCIATION_PARAM);
-        if(alreadyLoaded == null && hasDynamicAssociations) {
-            session.setAttribute(object, Neo4jEntityPersister.DYNAMIC_ASSOCIATION_PARAM, Boolean.TRUE);
+        if (id != null) {
+            Object alreadyLoaded = session.getAttribute(object, Neo4jEntityPersister.DYNAMIC_ASSOCIATION_PARAM);
+            if (alreadyLoaded == null && hasDynamicAssociations) {
+                session.setAttribute(object, Neo4jEntityPersister.DYNAMIC_ASSOCIATION_PARAM, Boolean.TRUE);
 
-            final String cypher = graphPersistentEntity.formatDynamicAssociationQuery();
-            final Map<String, Object> isMap = Collections.<String, Object>singletonMap(GormProperties.IDENTITY, id);
-            final StatementRunner boltSession = session.hasTransaction() ? session.getTransaction().getNativeTransaction() : session.getNativeInterface();
+                final String cypher = graphPersistentEntity.formatDynamicAssociationQuery();
+                final Map<String, Object> isMap = Collections.<String, Object>singletonMap(GormProperties.IDENTITY, id);
+                final StatementRunner boltSession = session.hasTransaction() ? session.getTransaction().getNativeTransaction() : session.getNativeInterface();
 
-            if(log.isDebugEnabled()) {
-                log.debug("QUERY Cypher [{}] for parameters [{}]", cypher, isMap);
-            }
-
-            final StatementResult relationships = boltSession.run(cypher, isMap);
-            while(relationships.hasNext()) {
-                final Record row = relationships.next();
-                String relType = row.get("relType").asString();
-                Boolean outGoing = row.get("out").asBoolean();
-                Map<String, Object> values = row.get("values").asMap();
-                TypeDirectionPair key = new TypeDirectionPair(relType, outGoing);
-                if(row.containsKey(RelationshipPendingInsert.TARGET_TYPE) && !row.get(RelationshipPendingInsert.TARGET_TYPE).isNull()) {
-                    key.setTargetType(
-                            row.get(RelationshipPendingInsert.TARGET_TYPE).asString()
-                    );
-                    relationshipsMap.put(key, values);
+                if (log.isDebugEnabled()) {
+                    log.debug("QUERY Cypher [{}] for parameters [{}]", cypher, isMap);
                 }
-            }
-            // if the relationship map is not empty as this point there are dynamic relationships that need to be loaded as undeclared
-            if (!relationshipsMap.isEmpty()) {
-                Neo4jMappingContext mappingContext = (Neo4jMappingContext) session.getMappingContext();
-                for (Map.Entry<TypeDirectionPair, Map<String,Object>> entry: relationshipsMap.entrySet()) {
-                    EntityAccess entityAccess = session.createEntityAccess(graphPersistentEntity, object);
-                    TypeDirectionPair key = entry.getKey();
-                    if (key.isOutgoing()) {
-                        Map<String, Object> relationshipData = entry.getValue();
-                        Object idsObject = relationshipData.get("ids");
-                        Object labelsObject = relationshipData.get("labels");
-                        if((idsObject instanceof Iterable) && (labelsObject instanceof Iterable)) {
 
-                            Iterator<Serializable> idIter = ((Iterable<Serializable>) idsObject).iterator();
-                            String targetType = key.getTargetType();
-                            Iterator<Collection<String>> labelIter = ((Iterable<Collection<String>>) labelsObject).iterator();
+                final StatementResult relationships = boltSession.run(cypher, isMap);
+                while (relationships.hasNext()) {
+                    final Record row = relationships.next();
+                    String relType = row.get("relType").asString();
+                    Boolean outGoing = row.get("out").asBoolean();
+                    Map<String, Object> values = row.get("values").asMap();
+                    TypeDirectionPair key = new TypeDirectionPair(relType, outGoing);
+                    if (row.containsKey(RelationshipPendingInsert.TARGET_TYPE) && !row.get(RelationshipPendingInsert.TARGET_TYPE).isNull()) {
+                        key.setTargetType(
+                            row.get(RelationshipPendingInsert.TARGET_TYPE).asString()
+                        );
+                        relationshipsMap.put(key, values);
+                    }
+                }
+                // if the relationship map is not empty as this point there are dynamic relationships that need to be loaded as undeclared
+                if (!relationshipsMap.isEmpty()) {
+                    Neo4jMappingContext mappingContext = (Neo4jMappingContext) session.getMappingContext();
+                    for (Map.Entry<TypeDirectionPair, Map<String, Object>> entry : relationshipsMap.entrySet()) {
+                        EntityAccess entityAccess = session.createEntityAccess(graphPersistentEntity, object);
+                        TypeDirectionPair key = entry.getKey();
+                        if (key.isOutgoing()) {
+                            Map<String, Object> relationshipData = entry.getValue();
+                            Object idsObject = relationshipData.get("ids");
+                            Object labelsObject = relationshipData.get("labels");
+                            if ((idsObject instanceof Iterable) && (labelsObject instanceof Iterable)) {
 
-                            List values = new ArrayList();
-                            GraphPersistentEntity associatedEntity = null;
-                            while (idIter.hasNext() && labelIter.hasNext()) {
-                                Serializable targetId = idIter.next();
-                                Collection<String> nextLabels = labelIter.next();
-                                Collection<String> labels = nextLabels.isEmpty() ? Collections.singletonList(targetType) : nextLabels;
-                                associatedEntity = mappingContext.findPersistentEntityForLabels(labels);
-                                if(associatedEntity == null) {
-                                    associatedEntity = mappingContext.findPersistentEntityForLabels(Collections.singletonList(targetType));
-                                }
-                                if(associatedEntity == null) {
-                                    continue;
-                                }
-                                Object proxy = mappingContext.getProxyFactory().createProxy(
+                                Iterator<Serializable> idIter = ((Iterable<Serializable>) idsObject).iterator();
+                                String targetType = key.getTargetType();
+                                Iterator<Collection<String>> labelIter = ((Iterable<Collection<String>>) labelsObject).iterator();
+
+                                List values = new ArrayList();
+                                GraphPersistentEntity associatedEntity = null;
+                                while (idIter.hasNext() && labelIter.hasNext()) {
+                                    Serializable targetId = idIter.next();
+                                    Collection<String> nextLabels = labelIter.next();
+                                    Collection<String> labels = nextLabels.isEmpty() ? Collections.singletonList(targetType) : nextLabels;
+                                    associatedEntity = mappingContext.findPersistentEntityForLabels(labels);
+                                    if (associatedEntity == null) {
+                                        associatedEntity = mappingContext.findPersistentEntityForLabels(Collections.singletonList(targetType));
+                                    }
+                                    if (associatedEntity == null) {
+                                        continue;
+                                    }
+                                    Object proxy = mappingContext.getProxyFactory().createProxy(
                                         session,
                                         associatedEntity.getJavaClass(),
                                         targetId
-                                );
-                                values.add(proxy);
+                                    );
+                                    values.add(proxy);
+                                }
+                                // for single instances and singular property name do not use an array
+                                Object value;
+                                if (values.size() == 1 && isSingular(key.getType())) {
+                                    value = IteratorUtil.singleOrNull(values);
+                                }
+                                else {
+                                    DynamicToManyAssociation dynamicAssociation = new DynamicToManyAssociation(graphPersistentEntity,
+                                                                                                               graphPersistentEntity.getMappingContext(),
+                                                                                                               key.getType(),
+                                                                                                               associatedEntity);
+                                    value = new Neo4jList(entityAccess, dynamicAssociation, values, session);
+                                }
+                                object.attributes().put(key.getType(), value);
                             }
-                            // for single instances and singular property name do not use an array
-                            Object value;
-                            if(values.size() == 1 && isSingular(key.getType())) {
-                                value = IteratorUtil.singleOrNull(values);
-                            }
-                            else {
-                                DynamicToManyAssociation dynamicAssociation = new DynamicToManyAssociation(graphPersistentEntity, graphPersistentEntity.getMappingContext(), key.getType(), associatedEntity);
-                                value = new Neo4jList(entityAccess, dynamicAssociation, values, session);
-                            }
-                            object.attributes().put(key.getType(), value);
-                        }
 
+                        }
                     }
                 }
+
             }
+
+        }
+        else {
+            session.setAttribute(object, Neo4jEntityPersister.DYNAMIC_ASSOCIATION_PARAM, Boolean.TRUE);
         }
 
         return relationshipsMap;

--- a/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/SchemalessSpec.groovy
+++ b/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/SchemalessSpec.groovy
@@ -397,6 +397,40 @@ class SchemalessSpec extends GormDatastoreSpec {
         Pet.findByName("Cosima").friends*.name.sort() == ["Bob","Lara"]
     }
 
+    def "Test update newly created object"() {
+        setup:
+        def victor = new Pet(name: 'Victor')
+        def fritz = new Pet(name: 'Fritz')
+        def franz = new Pet(name: 'Franz')
+        def heinrich = new Pet(name: 'Heinrich')
+        victor.buddies = [fritz, franz]
+
+        when:
+        victor.save()
+        heinrich.save()
+        session.flush()
+
+        then:
+        victor.buddies.name.sort() == ['Franz', 'Fritz']
+
+        when: "Adding an element"
+        victor.buddies.add(heinrich)
+        def cousin = victor.cousin
+
+        then:
+        victor.buddies.name.sort() == ['Franz', 'Fritz', 'Heinrich']
+
+        when:
+        victor.markDirty("buddies")
+        victor.save()
+        session.flush()
+        victor.discard()
+        victor = Pet.findByName("Victor")
+
+        then:
+        victor.buddies.name.sort() == ['Franz', 'Fritz', 'Heinrich']
+    }
+
 }
 
 


### PR DESCRIPTION
In a new object, as the session is not flagged with DYNAMIC_ASSOCIATION_PARAM attribute, when accessing a dynamic association, dynamic associations are loaded again discarding any edit.

Also checking if staticApi.gormPersistentEntity is instanceof GraphPersistentEntity, as it is giving trouble on some unit tests. In master we have the same issue: https://github.com/grails/gorm-neo4j/issues/77


