### PR TITLE
grails3-neo4j-hibernate example transaction fails on grails 4

### DIFF
--- a/examples/grails3-neo4j-hibernate/build.gradle
+++ b/examples/grails3-neo4j-hibernate/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     testCompile "org.seleniumhq.selenium:selenium-api:$seleniumVersion"
     testCompile "org.seleniumhq.selenium:selenium-support:$seleniumVersion"
 
-    testRuntime "org.neo4j.test:neo4j-harness:$neo4jVersion"
+    runtime "org.neo4j.test:neo4j-harness:$neo4jVersion"
 }
 webdriverBinaries {
     chromedriver "$chromeDriverVersion"

--- a/examples/grails3-neo4j/grails-app/controllers/functional/tests/BookController.groovy
+++ b/examples/grails3-neo4j/grails-app/controllers/functional/tests/BookController.groovy
@@ -38,7 +38,9 @@ class BookController {
             return
         }
 
-        book.save flush:true
+        Book.withTransaction {
+            book.save flush:true
+        }
 
         request.withFormat {
             form multipartForm {


### PR DESCRIPTION

Not sure if we should just use gorm-micronaut bindings everywhere instead for grails 4, but I wanted to provide these fixes either way.

- you can't run these embedded unless you change it from testRuntime to runtime

- I added a transaction here (weird), but removing static mapsWith = "neo4j" from the book class and updating the "show()" method int he BookController do the same thing. 

