### PR TITLE
Update Neo4jDataStoreSpringInitializer

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 assetPipelineVersion=3.3.3
 cglibNodepVersion=3.3.0
 chromeDriverVersion=2.44
-datastoreVersion=7.1.0.RC3
+datastoreVersion=7.1.0-SNAPSHOT
 gebVersion=2.3
 geckodriverVersion=0.23.0
 gparsVersion=1.2.1

--- a/grails-plugin/src/main/groovy/grails/neo4j/bootstrap/Neo4jDataStoreSpringInitializer.groovy
+++ b/grails-plugin/src/main/groovy/grails/neo4j/bootstrap/Neo4jDataStoreSpringInitializer.groovy
@@ -111,7 +111,7 @@ class Neo4jDataStoreSpringInitializer extends AbstractDatastoreInitializer {
             }
 
             loadDataServices(secondaryDatastore ? 'neo4j': null).each {serviceName, serviceClass->
-                "$serviceName"(DatastoreServiceMethodInvokingFactoryBean) {
+                "$serviceName"(DatastoreServiceMethodInvokingFactoryBean, serviceClass) {
                     targetObject = ref("neo4jDatastore")
                     targetMethod = 'getService'
                     arguments = [serviceClass]


### PR DESCRIPTION
Pass serviceClass to the constructor while loading DataService because sometime the closure is not evaluated early enough
to set it in the arguments which causes grails/grails-core#12057.